### PR TITLE
Fix energyUsage exceptions during the first hour of the day

### DIFF
--- a/src/pyeconet/equipment/water_heater.py
+++ b/src/pyeconet/equipment/water_heater.py
@@ -75,18 +75,14 @@ class EcoNetWaterHeater(object):
 
     @property
     def usage_unit(self):
-        if self._usage:
-            return self._usage["energyUsage"]["unit"]
-        return None
+        if self._usage and self._usage.get('energyUsage'):
+            return self._usage['energyUsage'].get('unit')
 
     @property
     def total_usage_for_today(self):
-        if self._usage:
-            hours = self._usage["energyUsage"]["hours"]
-            total = 0
-            for usage in hours.values():
-                total += usage
-            return total
+        if self._usage and self._usage.get('energyUsage'):
+            hours = self._usage['energyUsage'].get('hours', {})
+            return sum((usage for usage in hours.values()))
 
     def get_vacations(self):
         return self.vacations
@@ -94,7 +90,6 @@ class EcoNetWaterHeater(object):
     def dump_usage_json(self):
         if self._usage:
             return json.dumps(self._usage, indent=4, sort_keys=True)
-        return None
 
     def update_state(self):
         now = time.time()


### PR DESCRIPTION
Hi there! Thanks for your work on this library.

For the first ~hour or so of each day, I get lots of exceptions in my HA logs:

```
2019-01-07 00:03:18 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/homeassistant/helpers/entity.py", line 240, in async_update_ha_state
    device_attr = self.device_state_attributes
  File "/usr/local/lib/python3.6/site-packages/homeassistant/components/water_heater/econet.py", line 143, in device_state_attributes
    todays_usage = self.water_heater.total_usage_for_today
  File "/usr/local/lib/python3.6/site-packages/pyeconet/equipment/water_heater.py", line 85, in total_usage_for_today
    hours = self._usage["energyUsage"]["hours"]
KeyError: 'energyUsage'
```

... probably because the API hasn't calculated energy usage yet. This will cause the library to return None in that case, rather than raising an exception.