### PR TITLE
fix: do not update global HEADERS var (breaks re-login attempt)

### DIFF
--- a/src/pyeconet/api.py
+++ b/src/pyeconet/api.py
@@ -180,13 +180,13 @@ class EcoNetApiInterface:
         return _equipment
 
     async def _get_location(self) -> List[Dict]:
-        _headers = HEADERS
+        _headers = HEADERS.copy()
         _headers["ClearBlade-UserToken"] = self._user_token
 
         _session = ClientSession()
         try:
             async with _session.post(
-                f"{REST_URL}/code/{CLEAR_BLADE_SYSTEM_KEY}/getLocation", headers=HEADERS
+                f"{REST_URL}/code/{CLEAR_BLADE_SYSTEM_KEY}/getLocation", headers=_headers
             ) as resp:
                 if resp.status == 200:
                     _json = await resp.json()
@@ -204,7 +204,7 @@ class EcoNetApiInterface:
             await _session.close()
 
     async def get_dynamic_action(self, payload: Dict) -> Dict:
-        _headers = HEADERS
+        _headers = HEADERS.copy()
         _headers["ClearBlade-UserToken"] = self._user_token
 
         _session = ClientSession()
@@ -212,7 +212,7 @@ class EcoNetApiInterface:
             async with _session.post(
                 f"{REST_URL}/code/{CLEAR_BLADE_SYSTEM_KEY}/dynamicAction",
                 json=payload,
-                headers=HEADERS,
+                headers=_headers,
             ) as resp:
                 if resp.status == 200:
                     _json = await resp.json()


### PR DESCRIPTION
fixes the following:
1) attempt to use token (e.g.: to fetch locations)
2) token fails, out of date, etc
3) attempt to login with email+pw (even with a new api instance i.e.: EcoNetApiInterface.login())
4) clearblade user token header is still present in authenticate headers, login fails