### PR TITLE
build: allow install python=3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     ),
     install_requires=["aiohttp>=3.6.0", "paho-mqtt>=1.5.0"],
     keywords=["econet", "rheem", "api"],
-    python_requires=">=3.9, <4",
+    python_requires=">=3.8, <4",
     url="https://github.com/w1ll1am23/pyeconet",
     project_urls={
         "Bug Reports": "https://github.com/w1ll1am23/pyeconet/issues",


### PR DESCRIPTION
it works just fine on python 3.8.11 on my Sailfish OS mobile, so i've been lowering it manually to install