### PR TITLE
fix: always close session after authenticate

### DIFF
--- a/src/pyeconet/api.py
+++ b/src/pyeconet/api.py
@@ -232,20 +232,22 @@ class EcoNetApiInterface:
     async def _authenticate(self, payload: dict) -> None:
 
         _session = ClientSession()
-        async with _session.post(
-            f"{REST_URL}/user/auth", json=payload, headers=HEADERS
-        ) as resp:
-            if resp.status == 200:
-                _json = await resp.json()
-                _LOGGER.debug(_json)
-                if _json.get("options")["success"]:
-                    self._user_token = _json.get("user_token")
-                    self._account_id = _json.get("options").get("account_id")
-                else:
-                    raise InvalidCredentialsError(_json.get("options")["message"])
-            else:
-                raise GenericHTTPError(resp.status)
-        await _session.close()
+        try:
+          async with _session.post(
+              f"{REST_URL}/user/auth", json=payload, headers=HEADERS
+          ) as resp:
+              if resp.status == 200:
+                  _json = await resp.json()
+                  _LOGGER.debug(_json)
+                  if _json.get("options")["success"]:
+                      self._user_token = _json.get("user_token")
+                      self._account_id = _json.get("options").get("account_id")
+                  else:
+                      raise InvalidCredentialsError(_json.get("options")["message"])
+              else:
+                  raise GenericHTTPError(resp.status)
+        finally:
+          await _session.close()
 
     def _on_connect(self, client, userdata, flags, rc):
         _LOGGER.debug(f"Connected with result code: {str(rc)}")


### PR DESCRIPTION
fixes warning
```
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fe433155190>
Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x7fe433301470>, 644161.879763428)]']
connector: <aiohttp.connector.TCPConnector object at 0x7fe433155690>
```