### PR TITLE
fix: Fix blocking SSL calls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = pathlib.Path(__file__).parent.resolve()
 # Get the long description from the README file
 LONG_DESCRIPTION = (here / "README.md").read_text(encoding="utf-8")
 
-VERSION = "0.1.23"
+VERSION = "0.1.22"
 
 # Setting up
 setup(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = pathlib.Path(__file__).parent.resolve()
 # Get the long description from the README file
 LONG_DESCRIPTION = (here / "README.md").read_text(encoding="utf-8")
 
-VERSION = "0.1.22"
+VERSION = "0.1.23"
 
 # Setting up
 setup(

--- a/src/pyeconet/api.py
+++ b/src/pyeconet/api.py
@@ -35,7 +35,7 @@ ApiType = TypeVar("ApiType", bound="EcoNetApiInterface")
 
 def _create_ssl_context() -> ssl.SSLContext:
     """Create a SSL context for the MQTT connection."""
-    context = ssl.SSLContext(tls_version)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS)
     context.load_default_certs()
     return context
 


### PR DESCRIPTION
Home-Assistant reported that there is a blocking call due to the way the SSLContext is being setup (see https://github.com/home-assistant/core/issues/125380). This PR fixes the issue by setting up the context at import time and passing it to paho rather than letting paho create it's own context at execution.