### PR TITLE
fix: fix shutoff valve status check

### DIFF
--- a/src/pyeconet/equipment/water_heater.py
+++ b/src/pyeconet/equipment/water_heater.py
@@ -100,7 +100,7 @@ class WaterHeater(Equipment):
 
     @property
     def has_shutoff_valve(self) -> bool:
-        return self._equipment_info.get("@VALVE") is not None
+        return self._equipment_info.get("@VALVESTATUS", {}).get('title', "").startswith("Shut-OFF Valve - ")
 
     @property
     def running(self) -> bool:
@@ -137,7 +137,11 @@ class WaterHeater(Equipment):
     def shutoff_valve_open(self) -> Union[bool, None]:
         """Return if the shutoff valve is open or not"""
         if self.has_shutoff_valve:
-            return self._equipment_info.get("@VALVE")["value"] == 0
+            status = self._equipment_info.get("@VALVESTATUS")["title"]
+            if status == "Shut-OFF Valve - Open":
+                return True
+            elif status == "Shut-OFF Valve - Closed":
+                return False
         return None
 
     @property


### PR DESCRIPTION
After a leak detection event with my water heater today I noticed the way it's detecting the valve status doesn't match the changes in what econet sends. As far as I can tell the only difference is the title of the status. I can send example values if it helps.

I tested the change by patching my instance of home assistant. It now shows the correct state for the valve.