### PR TITLE
fix: Correct bad enum value on reading thermostat mode, also detect error …

### DIFF
--- a/src/pyeconet/api.py
+++ b/src/pyeconet/api.py
@@ -146,6 +146,8 @@ class EcoNetApiInterface:
             for _equip in _location.get("equiptments"):
                 # Early exit if server returned error code
                 if "error" in _equip:
+                    _LOGGER.error("EcoNet equipment error message"
+                                  f": {_equip.get('error')}")
                     continue
                 _equip_obj: Equipment = None
                 if (

--- a/src/pyeconet/api.py
+++ b/src/pyeconet/api.py
@@ -144,6 +144,9 @@ class EcoNetApiInterface:
         for _location in _locations:
             # They spelled it wrong...
             for _equip in _location.get("equiptments"):
+                # Early exit if server returned error code
+                if "error" in _equip:
+                    continue
                 _equip_obj: Equipment = None
                 if (
                     Equipment._coerce_type_from_string(_equip.get("device_type"))

--- a/src/pyeconet/equipment/thermostat.py
+++ b/src/pyeconet/equipment/thermostat.py
@@ -190,6 +190,15 @@ class Thermostat(Equipment):
     @property
     def mode(self) -> Union[ThermostatOperationMode, None]:
         """Return the current mode"""
+        if "@MODE" in self._equipment_info:
+            enumtext = self._equipment_info["@MODE"]['constraints']['enumText']
+            value = self._equipment_info["@MODE"]['value']
+            status = self._equipment_info["@MODE"]['status']
+            if (value != enumtext.index(status)):
+                _LOGGER.debug("Enum value mismatch: "
+                              f"{enumtext[value]} != "
+                              f"{self._equipment_info["@MODE"]['status']}")
+                self._equipment_info["@MODE"]['value'] = enumtext.index(status)
         return self.modes[self._equipment_info.get("@MODE")["value"]]
 
     @property


### PR DESCRIPTION
…messages from api and abandon equipment step

This is the alternative fix to enumeration fixing #45. This results in bad info in the equipment status and fixes it upon read.

Note, I added a fix to both this and https://github.com/w1ll1am23/pyeconet/pull/49 to detect error messages from the server and give up trying to match equipment that is not there. 