### PR TITLE
fix: Remove unknown parameter `force` from mqtt stop

### DIFF
--- a/src/pyeconet/api.py
+++ b/src/pyeconet/api.py
@@ -132,7 +132,7 @@ class EcoNetApiInterface:
         )
 
     def unsubscribe(self) -> None:
-        self._mqtt_client.loop_stop(force=True)
+        self._mqtt_client.loop_stop()
 
     def _get_client_id(self) -> str:
         time_string = str(time.time()).replace(".", "")[:13]


### PR DESCRIPTION
I don't know why this parameter is here. According to chatgpt it's never been a valid parameter.