### PR TITLE
fix: Fix bad enum from server (`api.py` version)

### DIFF
--- a/src/pyeconet/api.py
+++ b/src/pyeconet/api.py
@@ -144,6 +144,17 @@ class EcoNetApiInterface:
         for _location in _locations:
             # They spelled it wrong...
             for _equip in _location.get("equiptments"):
+                # Fix enumeration of Emergency Heat in Thermostat, maybe others?
+                if "@MODE" in _equip:
+                    # Need test that value exists?
+                    _enumtext = _equip["@MODE"]['constraints']['enumText']
+                    _value = _equip["@MODE"]['value']
+                    _status = _equip["@MODE"]['status']
+                    if (_value != _enumtext.index(_status)):
+                        _LOGGER.debug("Enum value mismatch: "
+                                      f"{_enumtext[_value]} != "
+                                      f"{_equip["@MODE"]['status']}")
+                        _equip["@MODE"]['value'] = _enumtext.index(_status)
                 _equip_obj: Equipment = None
                 if (
                     Equipment._coerce_type_from_string(_equip.get("device_type"))

--- a/src/pyeconet/api.py
+++ b/src/pyeconet/api.py
@@ -168,6 +168,8 @@ class EcoNetApiInterface:
             for _equip in _location.get("equiptments"):
                 # Early exit if server returned error code
                 if "error" in _equip:
+                    _LOGGER.error("EcoNet equipment error message"
+                                  f": {_equip.get('error')}")
                     continue
                 _equip, __ = self.check_mode_enum(_equip)
                 _equip_obj: Equipment = None


### PR DESCRIPTION
Apologies, this change was done on my master branch and got lost when I made branches for my other pull requests. This is the correct code for https://github.com/w1ll1am23/pyeconet/pull/49 to fix issue https://github.com/w1ll1am23/pyeconet/issues/45 as an alternate approach to https://github.com/w1ll1am23/pyeconet/pull/52

#52 makes the change in the thermostat class upon read, this makes the change in the api data from the server.