### PR TITLE
fix: Update todays_energy_usage to only start counting from hour 0

### DIFF
--- a/src/pyeconet/equipment/water_heater.py
+++ b/src/pyeconet/equipment/water_heater.py
@@ -251,8 +251,12 @@ class WaterHeater(Equipment):
     def todays_energy_usage(self) -> Union[float, None]:
         _total = 0
         if self._energy_usage:
-            for value in self._energy_usage.values():
-                _total += value
+            _found_today = False
+            for hour, value in self._energy_usage.items():
+                # Start summing once we find hour 0 (today's start)
+                if hour == 0 or _found_today:
+                    _found_today = True
+                    _total += value
             return _total
         else:
             return None


### PR DESCRIPTION
Fixes #63 by only counting hourly usage from the beginning of the current day (hour 0)

Proposed fix based on data I am seeing coming in from my water heater. I only have a single device, so I'm not sure whether this could cause issues with other Econet devices.