### PR TITLE
chore: Update pyupgrade version to v3.21.2

### DIFF
--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         stages: [manual]


### PR DESCRIPTION
Updates to the latest `pyupgrade` version. This addresses the PR lint check failures currently being observed. Example: https://github.com/w1ll1am23/pyeconet/actions/runs/22533024610/job/65275466451

The lint check installs Python 3.x, which current means installing 3.14.3. The old version 3.2.0 of `pyupgrade` is incompatible with the newer version of Python.