### PR TITLE
Fix MQTT SSL: use create_default_context() to respect SSL_CERT_FILE

### DIFF
--- a/src/pyeconet/api.py
+++ b/src/pyeconet/api.py
@@ -35,10 +35,17 @@ ApiType = TypeVar("ApiType", bound="EcoNetApiInterface")
 
 
 def _create_ssl_context() -> ssl.SSLContext:
-    """Create a SSL context for the MQTT connection."""
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS)
-    context.load_default_certs()
-    return context
+    """Create a TLS context for the MQTT connection.
+
+    Uses ssl.create_default_context() which enables certificate and hostname
+    verification and respects the SSL_CERT_FILE / REQUESTS_CA_BUNDLE
+    environment variables. This allows custom CA bundles to be supplied
+    without disabling verification — necessary on systems whose trust store
+    no longer includes the DigiCert Global Root CA (removed from
+    Mozilla/Linux ca-certificates on 2026-04-15) while rheem.clearblade.com
+    still chains to that root.
+    """
+    return ssl.create_default_context()
 
 
 _SSL_CONTEXT = _create_ssl_context()


### PR DESCRIPTION
## Problem

On systems whose `ca-certificates` bundle no longer includes **DigiCert Global Root CA (G1)** — removed from Mozilla/Linux bundles on 2026-04-15 — the MQTT connection to `rheem.clearblade.com` fails with:

```
SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate
```

`rheem.clearblade.com` still chains to the G1 root (`*.clearblade.com → DigiCert TLS RSA SHA256 2020 CA1 → DigiCert Global Root CA`). Updated Linux hosts (including current Home Assistant Container images) drop that root → OpenSSL can't verify the chain. Tracked upstream at [home-assistant/core#172228](https://github.com/home-assistant/core/issues/172228).

## Root cause in pyeconet

`_create_ssl_context()` builds the context manually:

```python
context = ssl.SSLContext(ssl.PROTOCOL_TLS)
context.load_default_certs()
```

`ssl.SSLContext(PROTOCOL_TLS)` defaults to `CERT_OPTIONAL` / `check_hostname=False` — weaker than necessary. More importantly, while `load_default_certs()` loads the system CA bundle, it does **not** honour `SSL_CERT_FILE` or `REQUESTS_CA_BUNDLE` environment variables, so users cannot supply a custom bundle without patching the library.

## Fix

Replace with `ssl.create_default_context()`:

- Enables `CERT_REQUIRED` + `check_hostname=True` (stricter, correct)
- Respects `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` environment variables
- Standard Python idiom; single line

The aiohttp `ClientSession()` paths already use `create_default_context()` internally, so this brings the MQTT path in line with the REST paths.

## Workaround for HA Container users (until ClearBlade reissues under G2/G3)

With this change, users can supply an augmented CA bundle via `SSL_CERT_FILE` in their `docker-compose.yml` without disabling verification. Detailed steps posted at [home-assistant/core#172228](https://github.com/home-assistant/core/issues/172228#issuecomment-4949403240).