### PR TITLE
fix: crash on first dict-valued field update, improve away-mode detection, add schedule resume

### DIFF
--- a/src/pyeconet/equipment/__init__.py
+++ b/src/pyeconet/equipment/__init__.py
@@ -25,12 +25,36 @@ class Equipment:
         self._api = api_interface
         self._equipment_info = equipment_info
         self._update_callback = None
+        self._awaiting_resume_confirmation = False
 
     def set_update_callback(self, callback):
         self._update_callback = callback
 
     def update_equipment_info(self, update: dict):
         """Take a dictionary and update the stored _equipment_info based on the present dict fields"""
+        # Some real-world actions (observed: ending a genuine Away/Vacation
+        # event via @SCHEDULERESUME) don't apply immediately - the cloud
+        # instead sends back a confirmation dialog and waits for the exact
+        # same payload to be re-published before actually applying it. Only
+        # auto-accept this when it's confirming something *we* just asked
+        # for, not any dialog that happens to arrive.
+        dialog = update.get("dialog")
+        if dialog is not None:
+            if self._awaiting_resume_confirmation:
+                self._awaiting_resume_confirmation = False
+                message = dialog.get("message")
+                if message:
+                    _LOGGER.debug(
+                        "Confirming resume-schedule dialog: %s", message
+                    )
+                    self._api.publish(message, self.device_id, self.serial_number)
+            else:
+                _LOGGER.debug(
+                    "Received unexpected confirmation dialog, not auto-accepting: %s",
+                    dialog,
+                )
+            return
+
         # Make sure this update is for this device, should probably check this before sending updates however
         _set = False
         if update.get("device_name") == self.device_id:
@@ -145,8 +169,15 @@ class Equipment:
         state - the app's own "exit vacation" action was observed to also
         send @SCHEDULERESUME, which is what actually resumes the schedule and
         lets the unit pick its own current scheduled mode.
+
+        Ending a genuine away/vacation event specifically triggers a
+        confirmation dialog from the cloud rather than applying immediately
+        (observed message: "Continuing will end Away Event") - see the
+        "dialog" handling in update_equipment_info, which auto-confirms it
+        as long as it arrives while a resume_schedule() call is outstanding.
         """
         if self.supports_schedule:
+            self._awaiting_resume_confirmation = True
             self._api.publish(
                 {"@SCHEDULERESUME": "resume"}, self.device_id, self.serial_number
             )

--- a/src/pyeconet/equipment/__init__.py
+++ b/src/pyeconet/equipment/__init__.py
@@ -101,12 +101,14 @@ class Equipment:
     @property
     def supports_away(self) -> bool:
         """Return if the user has enabled away mode functionality for this equipment."""
-        if "@AWAYCONFIG" in self._equipment_info:
-            return self._equipment_info.get("@AWAYCONFIG", False)
-        # Some units (e.g. certain water heaters) never send @AWAYCONFIG at all,
-        # even though they genuinely support and report away/vacation state via
-        # @AWAY. Fall back to treating @AWAY's presence as evidence of support.
-        return "@AWAY" in self._equipment_info
+        # Some units report @AWAYCONFIG as False in their full state snapshot
+        # (only sent once, on initial load, never in later incremental MQTT
+        # updates) even though they genuinely support and actively report
+        # away/vacation state via @AWAY. Trust real evidence of @AWAY support
+        # over a possibly-stale/inaccurate @AWAYCONFIG flag.
+        return bool(self._equipment_info.get("@AWAYCONFIG", False)) or (
+            "@AWAY" in self._equipment_info
+        )
 
     @property
     def away(self) -> bool:

--- a/src/pyeconet/equipment/__init__.py
+++ b/src/pyeconet/equipment/__init__.py
@@ -41,6 +41,11 @@ class Equipment:
                     )
                     try:
                         if isinstance(value, Dict):
+                            if not isinstance(self._equipment_info.get(key), Dict):
+                                # First time this dict-valued field has been seen
+                                # for this equipment (e.g. @AWAY_MSG only appears
+                                # once away/vacation messaging becomes relevant).
+                                self._equipment_info[key] = {}
                             for _key, _value in value.items():
                                 self._equipment_info[key][_key] = _value
                                 _LOGGER.debug(
@@ -96,7 +101,12 @@ class Equipment:
     @property
     def supports_away(self) -> bool:
         """Return if the user has enabled away mode functionality for this equipment."""
-        return self._equipment_info.get("@AWAYCONFIG", False)
+        if "@AWAYCONFIG" in self._equipment_info:
+            return self._equipment_info.get("@AWAYCONFIG", False)
+        # Some units (e.g. certain water heaters) never send @AWAYCONFIG at all,
+        # even though they genuinely support and report away/vacation state via
+        # @AWAY. Fall back to treating @AWAY's presence as evidence of support.
+        return "@AWAY" in self._equipment_info
 
     @property
     def away(self) -> bool:

--- a/src/pyeconet/equipment/__init__.py
+++ b/src/pyeconet/equipment/__init__.py
@@ -116,6 +116,44 @@ class Equipment:
         return self._equipment_info.get("@AWAY", False)
 
     @property
+    def supports_schedule(self) -> bool:
+        """Return if this equipment reports a native schedule status at all."""
+        return "@SCHEDULESTATUS" in self._equipment_info
+
+    @property
+    def schedule_status(self) -> Union[str, None]:
+        """Return the human-readable native schedule status.
+
+        Observed values on a real Rheem heat pump water heater:
+        "Following Schedule" or "Schedule overridden".
+        """
+        return self._equipment_info.get("@SCHEDULESTATUS")
+
+    @property
+    def is_following_schedule(self) -> bool:
+        """Return True if the equipment is currently following its own native
+        schedule rather than a manually overridden/held mode."""
+        return self.schedule_status == "Following Schedule"
+
+    def resume_schedule(self):
+        """Cancel any manual mode override (including away/vacation mode) and
+        resume the equipment's own native schedule.
+
+        This is distinct from simply setting @AWAY to False: on real hardware,
+        setting @AWAY alone does not necessarily make the physical unit (or
+        the app) stop treating the unit as being in an overridden/vacation
+        state - the app's own "exit vacation" action was observed to also
+        send @SCHEDULERESUME, which is what actually resumes the schedule and
+        lets the unit pick its own current scheduled mode.
+        """
+        if self.supports_schedule:
+            self._api.publish(
+                {"@SCHEDULERESUME": "resume"}, self.device_id, self.serial_number
+            )
+        else:
+            _LOGGER.error("Unit doesn't support schedule resume")
+
+    @property
     def connected(self) -> bool:
         """Return if the equipment is connected or not"""
         return self._equipment_info.get("@CONNECTED", True)


### PR DESCRIPTION
Four related fixes/additions, all reproduced and verified against real hardware (a Rheem heat pump water heater) across a full live-testing session.

## 1. Crash on the first dict-valued field update

`update_equipment_info()` assumes `self._equipment_info[key]` already exists as a dict when merging a dict-valued update:

```python
if isinstance(value, Dict):
    for _key, _value in value.items():
        self._equipment_info[key][_key] = _value
```

The first time a *new* dict-valued field (e.g. `@AWAY_MSG`) appears for a piece of equipment — typically the first time away/vacation messaging becomes relevant for a unit that's never used it before — `self._equipment_info[key]` doesn't exist yet, so the subscript raises a `KeyError`. That's silently caught by the broad `except Exception` and logged as `Failed to update with message`, dropping the field's update entirely.

Reproduced this live, at the exact moment Vacation Mode was first engaged from the Rheem app on a real device:

```
ERROR [pyeconet.equipment] Failed to update with message: {'@AWAY_MSG': {'value': 1, 'constraints': {...}, 'title': 'Unit is in Away Mode', 'status': ''}, '@AWAY': True, '@ACTIVE': True, '@STATUS': '', '@MODE': {'value': 5, 'status': 'Vacation'}, ...}
```

Fix: initialize `self._equipment_info[key]` as an empty dict before merging, when it isn't already a dict.

## 2. `supports_away` trusting a stale `@AWAYCONFIG`

This water heater's full state snapshot (sent once, on initial equipment load) always includes `"@AWAYCONFIG": false` — but away mode demonstrably works when driven through `@MODE`/`@AWAY` directly, confirmed by toggling real Vacation Mode from the app multiple times throughout testing. The original version of this fix trusted an explicit `@AWAYCONFIG` value first, which meant that stale `False` from the initial snapshot permanently masked real support after every startup.

`supports_away` now returns `True` if *either* field indicates support — trusting real evidence of `@AWAY` activity over a possibly-inaccurate `@AWAYCONFIG` flag — while still returning `True` when `@AWAYCONFIG` itself is `True`.

**Caveat found during full end-to-end testing (see #4): on this hardware, `@AWAY` by itself is largely cosmetic and does not reliably drive real Vacation Mode** — setting it alone doesn't change `@MODE` or get reflected in the Rheem app. It's `set_operation_mode("vacation")` (see the companion `home-assistant/core` PR) that does the real work. This fix is still correct and worth having (the feature flag/attribute should reflect real capability), just don't expect `set_away_mode` alone to be a complete vacation-entry mechanism on its own for this device.

## 3. `resume_schedule()` — cancel an override / exit vacation

Discovered while testing #2: simply setting `@AWAY` to `False` does not reliably take a unit out of an overridden state. Comparing captured MQTT traffic between the Rheem app's own "exit vacation" action and an `@AWAY`-only change made through this library, the app's action *also* sends `"@SCHEDULERESUME": "resume"` — this is what actually flips `@SCHEDULESTATUS` from `"Schedule overridden"` back to `"Following Schedule"` and lets the unit resume picking its own current scheduled mode.

Adds `supports_schedule` / `schedule_status` / `is_following_schedule` properties (mirroring the existing `supports_away`/`away` pattern) and `resume_schedule()`, which publishes `{"@SCHEDULERESUME": "resume"}`.

## 4. Confirmation dialog required to end a genuine Away Event

Found while live-testing #3 against a unit that was genuinely in Vacation Mode (as opposed to just a manually-overridden operation mode, which resumes immediately with no extra step): ending a real Away Event gets a `"dialog"` response instead of applying right away —

```json
{"dialog": {"constraint": {"message": "Continuing will end Away Event", "positive": "Accept", "negative": "Cancel", ...}, "message": {"@DESIRED_OVERRIDE": true, "is_away": false, "@SCHEDULERESUME": "resume", "@SCHEDULE": true, ...}}}
```

The app's own behavior (confirmed by watching real traffic) is to re-publish that `"message"` object as-is to accept the dialog. `update_equipment_info()` now does this automatically, gated on an `_awaiting_resume_confirmation` flag set by `resume_schedule()` itself — a dialog is only auto-accepted if it's confirming something this instance actually just asked for, not any dialog that happens to arrive unsolicited.

## Full end-to-end verification

With all four fixes applied, live-tested a complete real vacation cycle on the actual water heater (using a companion, not-yet-submitted `home-assistant/core` change that exposes `WaterHeaterOperationMode.VACATION` as a real selectable `operation_mode`, since HA core currently maps it to `STATE_OFF` and excludes it from `operation_list`):

1. `set_operation_mode("vacation")` → real Vacation Mode, **confirmed independently via the Rheem app** (not just HA's own state)
2. `resume_schedule()` → dialog appeared, was auto-confirmed, device settled into `@AWAY=false` / `@SCHEDULESTATUS="Following Schedule"` → **confirmed independently via the Rheem app showing Vacation Mode off**

## Testing

No existing test suite in this repo to extend, so I verified all fixes with a standalone script against real captured payloads and mock equipment (crash reproduction/fix, `supports_away` fallback in all combinations, `resume_schedule`/`schedule_status` behavior, dialog auto-confirm only when solicited) plus the full live-hardware round trip described above. Happy to add these as real test cases in the repo's structure if there's a preferred pattern — didn't see an existing `tests/` directory to match. Also happy to grab more debug logs from this hardware if useful for anything else in #61.