### PR TITLE
fix: Read @ENABLED for the on/off state instead of comparing an enum to a string

### DIFF
--- a/src/pyeconet/equipment/water_heater.py
+++ b/src/pyeconet/equipment/water_heater.py
@@ -220,11 +220,18 @@ class WaterHeater(Equipment):
 
     @property
     def enabled(self) -> Union[bool, None]:
-        """Return the the water heater is enabled or not"""
-        if self._supports_modes():
-            return self.modes[self._equipment_info.get("@MODE")["value"]] != "OFF"
-        elif self._supports_on_off():
+        """Return if the water heater is enabled or not"""
+        if self._supports_on_off():
+            # @ENABLED is the authoritative on/off flag. Units exposing both it
+            # and @MODE (e.g. heatpumpWaterHeaterGen5) leave @MODE on the last
+            # heating mode when switched off, so @MODE alone can't see the off
+            # state.
             return self._equipment_info.get("@ENABLED")["value"] == 1
+        elif self._supports_modes():
+            return (
+                self.modes[self._equipment_info.get("@MODE")["value"]]
+                is not WaterHeaterOperationMode.OFF
+            )
         else:
             # Unit doesn't support on/off or modes
             return None


### PR DESCRIPTION
## The bug

`WaterHeater.enabled` compares an `IntEnum` member to a string:

```python
if self._supports_modes():
    return self.modes[self._equipment_info.get("@MODE")["value"]] != "OFF"
```

`modes` holds `WaterHeaterOperationMode` members. An int is never equal to a string, so:

```
>>> WaterHeaterOperationMode.OFF != "OFF"
True
>>> WaterHeaterOperationMode.ENERGY_SAVING != "OFF"
True
```

The expression is always `True`, so `enabled` is effectively hardcoded `True` for any unit exposing `@MODE`. That makes the off-branch in `mode` unreachable:

```python
if self._supports_on_off():
    if not self.enabled:          # never taken
        return WaterHeaterOperationMode.OFF
```

Since that branch is the only place `@ENABLED` is consulted, on units exposing **both** fields the on/off flag never reaches callers at all.

## Why it matters

Those units don't record "off" in `@MODE`. On a `heatpumpWaterHeaterGen5`, switching the tank off sets `@ENABLED` to 0 and leaves `@MODE` on the last heating mode. Captured live from the device right after switching it off:

```
@MODE:    {"status": "Energy Saver  ", "value": 1,
           "constraints": {"enumText": ["Off", "Energy Saver", "Heat Pump",
                                        "High Demand", "Electric/Gas", "Vacation"]}}
@ENABLED: {"status": "Disabled", "value": 0,
           "constraints": {"enumText": ["Disabled", "Enabled"]}}
```

`mode` returns `ENERGY_SAVING` for a tank that is switched off.

Downstream in Home Assistant this surfaces twice: the `water_heater` entity reports `eco` while the tank is off, and because that entity is a mode dropdown driven by `current_operation` (`supported_features: 7`, no `ON_OFF`), it already reads `eco` and there is no state left to select to switch the tank back on. The only way back on is the Rheem app.

## The fix

Check `@ENABLED` first when the unit supports it, since it is the authoritative on/off flag, and fall back to `@MODE` otherwise. Also compare against the enum member rather than a string, so the `@MODE` path detects `OFF` correctly on units that have no `@ENABLED`.

## Verification

No test suite in the repo, so I ran the three device shapes against a captured `heatpumpWaterHeaterGen5` payload plus synthetic modes-only and on/off-only units:

| case | `enabled` | `mode` | before | after |
|---|---|---|---|---|
| `@MODE`+`@ENABLED`, on, Energy Saver | True | `ENERGY_SAVING` | pass | pass |
| `@MODE`+`@ENABLED`, off (`@MODE` stays 1) | False | `OFF` | **fail** (`True` / `ENERGY_SAVING`) | pass |
| `@MODE`+`@ENABLED`, off (`@MODE` echoed 0) | False | `OFF` | **fail** (`enabled` `True`) | pass |
| modes-only, `@MODE`=Off | False | `OFF` | **fail** (`enabled` `True`) | pass |
| modes-only, `@MODE`=Energy Saver | True | `ENERGY_SAVING` | pass | pass |
| on/off-only, `@ENABLED`=0 | False | `OFF` | pass | pass |
| on/off-only, `@ENABLED`=1 | True | `ELECTRIC_MODE` | pass | pass |

3 of 7 fail before, all 7 pass after. No behaviour change for on/off-only units.

Also running the equivalent patch against my own Gen5 through Home Assistant: selecting Off now holds at `off` instead of snapping back to `eco` within the same second, and selecting Eco switches the tank back on.